### PR TITLE
Revert "Remove KPublicTransport"

### DIFF
--- a/org.kde.kongress.json
+++ b/org.kde.kongress.json
@@ -39,6 +39,32 @@
             ]
         },
         {
+            "name": "kpublictransport",
+            "config-opts": [
+                "-DBUILD_TESTING=OFF"
+            ],
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/release-service/24.08.1/src/kpublictransport-24.08.1.tar.xz",
+                    "sha256": "cb7305cff8d6058f1773b84f7e2ced82614c976854c13b455fab49732ad656a7",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 8763,
+                        "stable-only": true,
+                        "url-template": "https://download.kde.org/stable/release-service/$version/src/kpublictransport-$version.tar.xz"
+                    }
+                }
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/cmake",
+                "/mkspecs"
+            ]
+        },
+        {
             "name": "kopeninghours",
             "config-opts": [
                 "-DBUILD_TESTING=OFF",


### PR DESCRIPTION
Reverts flathub/org.kde.kongress#31

```
 ?libQt6Qml.so.6?|QQmlApplicationEnginePrivate::startLoad|?kongress? QQmlApplicationEngine failed to load component
 ?libQt6Qml.so.6?|QQmlEnginePrivate::warning|?libQt6Qml.so.6? qrc:/qt/qml/org/kde/kongress/Main.qml:104:9: Type IndoorMapView unavailable
 ?libQt6Qml.so.6?|QQmlEnginePrivate::warning|?libQt6Qml.so.6? qrc:/qt/qml/org/kde/kongress/IndoorMapView.qml:12:1: module "org.kde.kosmindoorrouting" is not installed
```

https://invent.kde.org/utilities/kongress/-/merge_requests/64#note_1031851